### PR TITLE
Fix constraint attributes import

### DIFF
--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -834,8 +834,9 @@ namespace ILRepacking
         {
             foreach (GenericParameterConstraint gpc in input)
             {
-                gpc.ConstraintType = Import(gpc.ConstraintType, context);
-                output.Add(gpc);
+                var newGpc = new GenericParameterConstraint(Import(gpc.ConstraintType, context));
+                CopyCustomAttributes(gpc.CustomAttributes, newGpc.CustomAttributes, context);
+                output.Add(newGpc);
             }
         }
 


### PR DESCRIPTION
This PR fixes attributes not being correctly imported for generic constraints, resulting in an exception at merge time.

It's necessary when nullable reference types are enabled: generic type constraints will have a `NullableAttribute` added by the C# compiler.